### PR TITLE
event registration page protection

### DIFF
--- a/CRM/Civihoneypot/Form/HoneypotSettings.php
+++ b/CRM/Civihoneypot/Form/HoneypotSettings.php
@@ -31,31 +31,42 @@ class CRM_Civihoneypot_Form_HoneypotSettings extends CRM_Core_Form {
   function buildQuickForm() {
     $this->addEntityRef('form_ids',
       ts('Contribution Page(s)'),
-      array(
+      [
         'entity' => 'ContributionPage',
         'placeholder' => ts('- Select Contribution Page -'),
-        'select' => array('minimumInputLength' => 0),
+        'select' => ['minimumInputLength' => 0],
         'multiple' => TRUE,
-        'api' => array('label_field' => 'title'),
-      )
+        'api' => ['label_field' => 'title'],
+      ],
     );
-    $this->add('text', 'field_names', ts('Field Names', array('domain' => 'com.elisseck.civihoneypot')), TRUE);
-    $this->add('advcheckbox', 'protect_all', ts('Protect All Pages', array('domain' => 'com.elisseck.civihoneypot')));
-    $this->add('text', 'limit', ts('Time Limiter (in secs)', array('domain' => 'com.elisseck.civihoneypot')));
-    $this->add('textarea', 'ipban', ts('Banned IP Address(es)', array('domain' => 'com.elisseck.civihoneypot')));
-    $this->addFormRule(array('CRM_Civihoneypot_Form_HoneypotSettings', 'formRule'), $this);
+    $this->add('text', 'field_names', ts('Field Names', ['domain' => 'com.elisseck.civihoneypot']), TRUE);
+    $this->add('advcheckbox', 'protect_all', ts('Protect All Contribution Pages', ['domain' => 'com.elisseck.civihoneypot']));
+    $this->addEntityRef('event_ids',
+      ts('Event Registration Form(s)'),
+      [
+        'entity' => 'Event',
+        'placeholder' => ts('- Select Event -'),
+        'select' => ['minimumInputLength' => 0],
+        'multiple' => TRUE,
+        'api' => ['label_field' => 'title'],
+      ],
+    );
+    $this->add('advcheckbox', 'protect_all_events', ts('Protect All Events', ['domain' => 'com.elisseck.civihoneypot']));
+    $this->add('text', 'limit', ts('Time Limiter (in secs)', ['domain' => 'com.elisseck.civihoneypot']));
+    $this->add('textarea', 'ipban', ts('Banned IP Address(es)', ['domain' => 'com.elisseck.civihoneypot']));
+    $this->addFormRule(['CRM_Civihoneypot_Form_HoneypotSettings', 'formRule'], $this);
 
-    $this->addButtons(array(
-      array(
+    $this->addButtons([
+      [
         'type' => 'submit',
-        'name' => ts('Submit', array('domain' => 'com.elisseck.civihoneypot')),
+        'name' => ts('Submit', ['domain' => 'com.elisseck.civihoneypot']),
         'isDefault' => TRUE,
-      ),
-      array(
+      ],
+      [
         'type' => 'cancel',
-        'name' => ts('Cancel', array('domain' => 'com.elisseck.civihoneypot')),
-      ),
-    ));
+        'name' => ts('Cancel', ['domain' => 'com.elisseck.civihoneypot']),
+      ],
+    ]);
     parent::buildQuickForm();
   }
 
@@ -72,7 +83,7 @@ class CRM_Civihoneypot_Form_HoneypotSettings extends CRM_Core_Form {
    *   true if no errors, else array of errors
    */
   public static function formRule($fields, $files, $self) {
-    $errors = array();
+    $errors = [];
     if ($fields['protect_all'] != "1" && empty($fields['form_ids'])) {
       $errors['_qf_default'] = ts('You must either select at least one form or check the "Protect All" box');
     }

--- a/civihoneypot.php
+++ b/civihoneypot.php
@@ -24,9 +24,18 @@ function _getHoneypotValues() {
  */
 function civihoneypot_civicrm_buildForm($formName, &$form) {
   $settings = _getHoneypotValues();
+  $protect = FALSE;
   if ($formName == 'CRM_Contribute_Form_Contribution_Main' &&
-    ($settings['protect_all'] == "1" || (in_array($form->getVar('_id'), CRM_Utils_Array::value('form_ids', $settings, array()))))
+    ($settings['protect_all'] == "1" || (in_array($form->getVar('_id'), CRM_Utils_Array::value('form_ids', $settings, []))))
   ) {
+    $protect = TRUE;
+  }
+  if ($formName == 'CRM_Event_Form_Registration_Register' &&
+    ($settings['protect_all_events'] == "1" || (in_array($form->getVar('_id'), CRM_Utils_Array::value('event_ids', $settings, []))))
+  ) {
+    $protect = TRUE;
+  }
+  if ($protect) {
 	  $deny = CRM_Utils_Array::value('ipban', $settings, array());
       if ($deny) {
 	    $remote = $_SERVER['REMOTE_ADDR'];
@@ -77,10 +86,19 @@ function civihoneypot_civicrm_buildForm($formName, &$form) {
  */
 function civihoneypot_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   $settings = _getHoneypotValues();
-	//check for honeypot field values from randomized fields
+  //check for honeypot field values from randomized fields
+  $protect = FALSE;
   if ($formName == 'CRM_Contribute_Form_Contribution_Main' &&
-    ($settings['protect_all'] == "1" || (in_array($form->getVar('_id'), CRM_Utils_Array::value('form_ids', $settings, array()))))
+    ($settings['protect_all'] == "1" || (in_array($form->getVar('_id'), CRM_Utils_Array::value('form_ids', $settings, []))))
   ) {
+    $protect = TRUE;
+  }
+  if ($formName == 'CRM_Event_Form_Registration_Register' &&
+    ($settings['protect_all_events'] == "1" || (in_array($form->getVar('_id'), CRM_Utils_Array::value('event_ids', $settings, []))))
+  ) {
+    $protect = TRUE;
+  }
+  if ($protect) {
     if ($limit = CRM_Utils_Array::value('limit', $settings)) {
       $delay = ($_SERVER['REQUEST_TIME'] - $fields['timestamp']);
       if ($delay < $limit) {

--- a/templates/CRM/Civihoneypot/Form/HoneypotSettings.tpl
+++ b/templates/CRM/Civihoneypot/Form/HoneypotSettings.tpl
@@ -13,6 +13,16 @@
           <p class="description">{ts domain='com.elisseck.civihoneypot'}Alternatively, protect all contribution pages by ticking this checkbox{/ts}</p></td>
       </tr>
       <tr>
+        <td class="label">{$form.event_ids.label}</td>
+        <td class="content">{$form.event_ids.html}
+          <p class="description">{ts domain='com.elisseck.civihoneypot'}Choose which event registration forms you would like to protect{/ts}</p></td>
+      </tr>
+      <tr>
+        <td class="label">{$form.protect_all_events.label}</td>
+        <td class="content">{$form.protect_all_events.html}
+          <p class="description">{ts domain='com.elisseck.civihoneypot'}Alternatively, protect all event registration forms by ticking this checkbox{/ts}</p></td>
+      </tr>
+      <tr>
         <td class="label">{$form.field_names.label}</td>
         <td class="content">{$form.field_names.html}
           <p class="description">{ts domain='com.elisseck.civihoneypot'}Names for honeypot fields - use a comma separated list for multiple randomized names e.g. url,link,username{/ts}</p></td>

--- a/templates/civihoneypot.tpl
+++ b/templates/civihoneypot.tpl
@@ -9,8 +9,12 @@
 </div>
 {* reposition the above block after #someOtherBlock *}
 <script type="text/javascript">
-  CRM.$('#{$fieldname}').insertAfter('.custom_pre_profile-group')
-  CRM.$('#timestamp').insertAfter('.custom_pre_profile-group')
+  // For Contribution Pages
+  CRM.$('#{$fieldname}').insertAfter('.custom_pre_profile-group');
+  CRM.$('#timestamp').insertAfter('.custom_pre_profile-group');
+  // For Event Pages
+  CRM.$('#{$fieldname}').insertAfter('.custom_pre-section');
+  CRM.$('#timestamp').insertAfter('.custom_pre-section');
   CRM.$('input[name={$fieldname}]').prop('required',true);
   CRM.$('input[name=timestamp]').attr('value',{$timestamp}).prop('readonly',true);
   CRM.$('#Main').attr('novalidate','novalidate');


### PR DESCRIPTION
This extends CiviHoneypot protection to event pages.

I realize I shouldn't have converted array syntax in the same PR, and I apologize for that - but the heart of this isn't very drastic.  I add two new settings (event IDs to protect, protect all events), update the JS to put the hidden fields in the correct place on event pages, and change the logic of whether to protect a page to support the new options.