### PR TITLE
Avoid parse errors with PHP 7.2

### DIFF
--- a/CRM/Civihoneypot/Form/HoneypotSettings.php
+++ b/CRM/Civihoneypot/Form/HoneypotSettings.php
@@ -43,7 +43,7 @@ class CRM_Civihoneypot_Form_HoneypotSettings extends CRM_Core_Form {
         'select' => ['minimumInputLength' => 0],
         'multiple' => TRUE,
         'api' => ['label_field' => 'title'],
-      ],
+      ]
     );
     $this->add('text', 'honeypot_field_names', E::ts('Field Names'), TRUE);
     $this->add('advcheckbox', 'honeypot_protect_all', E::ts('Protect All Contribution Pages'));
@@ -55,7 +55,7 @@ class CRM_Civihoneypot_Form_HoneypotSettings extends CRM_Core_Form {
         'select' => ['minimumInputLength' => 0],
         'multiple' => TRUE,
         'api' => ['label_field' => 'title'],
-      ],
+      ]
     );
     $this->add('advcheckbox', 'honeypot_protect_all_events', E::ts('Protect All Events'));
     $this->add('text', 'honeypot_limit', E::ts('Time Limiter (in secs)'));


### PR DESCRIPTION
With PHP 7.4 the code works as expected but fails with PHP 7.2. A parse error is raised because another argument is expected after the comma.